### PR TITLE
ci: add Codecov upload step for code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,40 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  detect-changed-crates:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.set-matrix.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed files
+        id: diff
+        run: |
+          echo "::set-output name=files::$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})"
+      - name: Detect changed crates
+        id: set-matrix
+        run: |
+          changed_crates=()
+          for crate in components/*; do
+            if [ -d "$crate" ]; then
+              crate_name=$(basename "$crate")
+              for file in ${{ steps.diff.outputs.files }}; do
+                if [[ $file == $crate/* ]]; then
+                  changed_crates+=("$crate_name")
+                  break
+                fi
+              done
+            fi
+          done
+          if [ ${#changed_crates[@]} -eq 0 ]; then
+            echo "No crates changed. Defaulting to all."
+            changed_crates=($(ls components))
+          fi
+          matrix=$(printf ',"%s"' "${changed_crates[@]}")
+          matrix="[${matrix:1}]"
+          echo "Changed crates: $matrix"
+          echo "::set-output name=changed::$matrix"
+
   lint:
     if: |
       contains(github.event.pull_request.labels.*.name, 'run-ci') && !contains(github.event.pull_request.labels.*.name, 'ignore-ci')
@@ -40,10 +74,14 @@ jobs:
       - name: Build docs
         run: cargo doc --workspace --no-deps --document-private-items
   build-and-test:
+    needs: detect-changed-crates
     if: |
       contains(github.event.pull_request.labels.*.name, 'run-ci') && !contains(github.event.pull_request.labels.*.name, 'ignore-ci')
-    name: Build and Test
+    name: Build and Test ${{ matrix.crate }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        crate: ${{fromJson(needs.detect-changed-crates.outputs.changed)}}
     steps:
       - uses: actions/checkout@v4
       - name: Remove unwanted files
@@ -54,19 +92,19 @@ jobs:
           shared-key: "rust-cache-${{ hashFiles('**/Cargo.lock') }}"
           cache-on-failure: true
       - name: Build
-        run: cargo build --workspace --all-targets
+        run: cargo build -p ${{ matrix.crate }} --all-targets
       - name: Test
-        run: cargo test --workspace --all-targets
-      - name: Install tarpaulin
-        run: cargo install cargo-tarpaulin --locked
+        run: cargo test -p ${{ matrix.crate }} --all-targets
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
       - name: Run code coverage
-        run: cargo tarpaulin --workspace --all --out Xml
+        run: cargo llvm-cov --package ${{ matrix.crate }} --all-features --lcov --output-path lcov.info
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
-          path: cobertura.xml
+          name: coverage-report-${{ matrix.crate }}
+          path: lcov.info
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: cobertura.xml
+          files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,16 @@ jobs:
         run: cargo build --workspace --all-targets
       - name: Test
         run: cargo test --workspace --all-targets
+      - name: Install tarpaulin
+        run: cargo install cargo-tarpaulin --locked
+      - name: Run code coverage
+        run: cargo tarpaulin --workspace --all --out Xml
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: cobertura.xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: cobertura.xml

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ components/data-profiler/data/*.log
 *.swp
 *.bak
 create_etl_maturity_issues.sh
+
+# Local scripts/tools
+check-unused-deps.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+[profile.dev]
+opt-level = 1
 [workspace]
 members = [
     "components/conform",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # rETL: Modular Rust ETL Pipeline
 
 [![CI](https://github.com/Uh-X3L/rETL/actions/workflows/ci.yml/badge.svg)](https://github.com/Uh-X3L/rETL/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Uh-X3L/rETL/branch/main/graph/badge.svg)](https://codecov.io/gh/Uh-X3L/rETL)
 
 rETL is a modular, extensible ETL (Extract, Transform, Load) framework written in Rust, designed for data engineering and analytics workflows. The project is organized as a Rust workspace with separate crates for each ETL stage.
 


### PR DESCRIPTION
- Integrate codecov/codecov-action to upload tarpaulin coverage reports
- Remove unnecessary token for public repo compatibility
- Ensures code coverage is reported and badge is updated automatically
Closes #4 